### PR TITLE
Add code coverage to appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,6 +4,9 @@ image:
   - Visual Studio 2019
 
 install:
+  - cinst OpenCppCoverage
+  - cinst codecov
+  - refreshenv
   - cinst openssl
 
 configuration:
@@ -16,3 +19,7 @@ before_build:
 test_script:
   - cd build
   - ctest -C %CONFIGURATION% --output-on-failure
+
+after_test:
+  - OpenCppCoverage --cover_children --sources=%APPVEYOR_BUILD_FOLDER% --export_type=cobertura:cobertura.xml -- ctest -C %CONFIGURATION%
+  - codecov --no-color -f cobertura.xml

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Windows SSPI/Schannel implementation of boost::asio::ssl
+Windows SSPI/SChannel implementation of boost::asio::ssl
 ========================================================
 
 Work in progress. Nowhere near being in a usable state.
@@ -7,4 +7,5 @@ Work in progress. Nowhere near being in a usable state.
 Build status
 ------------
 
-[![Build status](https://ci.appveyor.com/api/projects/status/x70rnwegdyphwunp/branch/master?svg=true)](https://ci.appveyor.com/project/laudrup/boost-asio-windows-sspi/branch/master)
+[![Build status](https://ci.appveyor.com/api/projects/status/x70rnwegdyphwunp/branch/master?svg=true)](https://ci.appveyor.com/project/laudrup/boost-windows-sspi/branch/master)
+[![codecov](https://codecov.io/gh/laudrup/boost-windows-sspi/branch/master/graph/badge.svg)](https://codecov.io/gh/laudrup/boost-windows-sspi)


### PR DESCRIPTION
Use OpenCppCoverage for generating code coverage and upload the result
to codecov.io.