### PR TITLE
Extend unittest to make client read response

### DIFF
--- a/include/boost/windows_sspi/detail/config.hpp
+++ b/include/boost/windows_sspi/detail/config.hpp
@@ -1,0 +1,24 @@
+//
+// windows_sspi/detail/config.hpp
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//
+// Copyright (c) 2020 Kasper Laudrup (laudrup at stacktrace dot dk)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef BOOST_WINDOWS_SSPI_DETAIL_CONFIG_HPP
+#define BOOST_WINDOWS_SSPI_DETAIL_CONFIG_HPP
+
+#include <boost/asio.hpp>
+
+namespace boost {
+namespace windows_sspi {
+
+namespace net = boost::asio;
+
+} // namespace windows_sspi
+} // namespace boost
+
+#endif // BOOST_WINDOWS_SSPI_DETAIL_CONFIG_HPP

--- a/include/boost/windows_sspi/detail/sspi_impl.hpp
+++ b/include/boost/windows_sspi/detail/sspi_impl.hpp
@@ -21,25 +21,14 @@ namespace detail {
 
 namespace net = boost::asio;
 
-class sspi_impl {
+class sspi_encrypt {
 public:
-  sspi_impl(CtxtHandle* context)
+  sspi_encrypt(CtxtHandle* context)
     : m_context(context) {
   }
 
-  // TODO: Calculate this once when handshake is complete
-  SecPkgContext_StreamSizes stream_sizes() const {
-    SecPkgContext_StreamSizes stream_sizes;
-    SECURITY_STATUS sc = detail::sspi_functions::QueryContextAttributes(m_context, SECPKG_ATTR_STREAM_SIZES, &stream_sizes);
-
-    // TODO: Signal error to user (throw exception or use error code?)
-    boost::ignore_unused(sc);
-    BOOST_ASSERT(sc == SEC_E_OK);
-    return stream_sizes;
-  }
-
   template <typename ConstBufferSequence>
-  std::vector<char> encrypt(const ConstBufferSequence& buffers, boost::system::error_code& ec, size_t& size_encrypted) {
+  std::vector<char> operator()(const ConstBufferSequence& buffers, boost::system::error_code& ec, size_t& size_encrypted) {
     SecBufferDesc Message;
     SecBuffer Buffers[4];
 
@@ -76,7 +65,28 @@ public:
     return message;
   }
 
-  SECURITY_STATUS decrypt(const std::vector<char>& data) {
+private:
+  // TODO: Calculate this once when handshake is complete
+  SecPkgContext_StreamSizes stream_sizes() const {
+    SecPkgContext_StreamSizes stream_sizes;
+    SECURITY_STATUS sc = detail::sspi_functions::QueryContextAttributes(m_context, SECPKG_ATTR_STREAM_SIZES, &stream_sizes);
+
+    // TODO: Signal error to user (throw exception or use error code?)
+    boost::ignore_unused(sc);
+    BOOST_ASSERT(sc == SEC_E_OK);
+    return stream_sizes;
+  }
+
+  CtxtHandle* m_context;
+};
+
+class sspi_decrypt {
+public:
+  sspi_decrypt(CtxtHandle* context)
+    : m_context(context) {
+  }
+
+  SECURITY_STATUS operator()(const std::vector<char>& data) {
     encrypted_data.insert(encrypted_data.end(), data.begin(), data.end());
 
     SecBufferDesc Message;
@@ -117,6 +127,17 @@ public:
 
 private:
   CtxtHandle* m_context;
+};
+
+class sspi_impl {
+public:
+  sspi_impl(CtxtHandle* context)
+    : encrypt(context)
+    , decrypt(context) {
+  }
+
+  sspi_encrypt encrypt;
+  sspi_decrypt decrypt;
 };
 
 } // namespace detail

--- a/include/boost/windows_sspi/detail/sspi_impl.hpp
+++ b/include/boost/windows_sspi/detail/sspi_impl.hpp
@@ -12,14 +12,13 @@
 #define BOOST_WINDOWS_SSPI_DETAIL_SSPI_IMPL_HPP
 
 #include <boost/windows_sspi/detail/sspi_functions.hpp>
+#include <boost/windows_sspi/detail/config.hpp>
 
 #include <boost/core/ignore_unused.hpp>
 
 namespace boost {
 namespace windows_sspi {
 namespace detail {
-
-namespace net = boost::asio;
 
 class sspi_encrypt {
 public:

--- a/include/boost/windows_sspi/detail/sspi_impl.hpp
+++ b/include/boost/windows_sspi/detail/sspi_impl.hpp
@@ -190,6 +190,10 @@ public:
   }
 
   std::vector<char> get(std::size_t max) {
+    // TODO: Figure out a way to avoid removing from the front of the
+    // vector. Since the caller will ask for decrypted data as long as
+    // it's there, this buffer should just give out chunks from the
+    // beginning until it's empty.
     std::size_t size = std::min(max, decrypted_data.size());
     std::vector<char> ret{decrypted_data.begin(), decrypted_data.begin() + size};
     decrypted_data.erase(decrypted_data.begin(), decrypted_data.begin() + size);

--- a/include/boost/windows_sspi/detail/sspi_impl.hpp
+++ b/include/boost/windows_sspi/detail/sspi_impl.hpp
@@ -127,7 +127,7 @@ private:
 class sspi_decrypt {
 public:
   sspi_decrypt(CtxtHandle* context)
-    : error_code(SEC_E_OK)
+    : last_error(SEC_E_OK)
     , m_context(context) {
   }
 
@@ -159,11 +159,11 @@ public:
     Message.cBuffers = 4;
     Message.pBuffers = Buffers;
 
-    error_code = detail::sspi_functions::DecryptMessage(m_context, &Message, 0, NULL);
-    if (error_code == SEC_E_INCOMPLETE_MESSAGE) {
+    last_error = detail::sspi_functions::DecryptMessage(m_context, &Message, 0, NULL);
+    if (last_error == SEC_E_INCOMPLETE_MESSAGE) {
       return state::data_needed;
     }
-    if (error_code != SEC_E_OK) {
+    if (last_error != SEC_E_OK) {
       return state::error;
     }
 
@@ -199,7 +199,7 @@ public:
   // TODO: Make private
   std::vector<char> encrypted_data;
   std::vector<char> decrypted_data;
-  SECURITY_STATUS error_code;
+  SECURITY_STATUS last_error;
 
 private:
   CtxtHandle* m_context;

--- a/include/boost/windows_sspi/detail/sspi_impl.hpp
+++ b/include/boost/windows_sspi/detail/sspi_impl.hpp
@@ -1,0 +1,126 @@
+//
+// windows_sspi/detail/sspi_impl.hpp
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//
+// Copyright (c) 2020 Kasper Laudrup (laudrup at stacktrace dot dk)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef BOOST_WINDOWS_SSPI_DETAIL_SSPI_IMPL_HPP
+#define BOOST_WINDOWS_SSPI_DETAIL_SSPI_IMPL_HPP
+
+#include <boost/windows_sspi/detail/sspi_functions.hpp>
+
+#include <boost/core/ignore_unused.hpp>
+
+namespace boost {
+namespace windows_sspi {
+namespace detail {
+
+namespace net = boost::asio;
+
+class sspi_impl {
+public:
+  sspi_impl(CtxtHandle* context)
+    : m_context(context) {
+  }
+
+  // TODO: Calculate this once when handshake is complete
+  SecPkgContext_StreamSizes stream_sizes() const {
+    SecPkgContext_StreamSizes stream_sizes;
+    SECURITY_STATUS sc = detail::sspi_functions::QueryContextAttributes(m_context, SECPKG_ATTR_STREAM_SIZES, &stream_sizes);
+
+    // TODO: Signal error to user (throw exception or use error code?)
+    boost::ignore_unused(sc);
+    BOOST_ASSERT(sc == SEC_E_OK);
+    return stream_sizes;
+  }
+
+  template <typename ConstBufferSequence>
+  std::vector<char> encrypt(const ConstBufferSequence& buffers, boost::system::error_code& ec, size_t& size_encrypted) {
+    SecBufferDesc Message;
+    SecBuffer Buffers[4];
+
+    // TODO: Consider encrypting all buffer contents before returning
+    size_encrypted = std::min(net::buffer_size(buffers), static_cast<size_t>(stream_sizes().cbMaximumMessage));
+    std::vector<char> message(stream_sizes().cbHeader + size_encrypted + stream_sizes().cbTrailer);
+
+    Buffers[0].pvBuffer = message.data();
+    Buffers[0].cbBuffer = stream_sizes().cbHeader;
+    Buffers[0].BufferType = SECBUFFER_STREAM_HEADER;
+
+    net::buffer_copy(net::buffer(message.data() + stream_sizes().cbHeader, size_encrypted), buffers);
+    Buffers[1].pvBuffer = message.data() + stream_sizes().cbHeader;
+    Buffers[1].cbBuffer = static_cast<ULONG>(size_encrypted);
+    Buffers[1].BufferType = SECBUFFER_DATA;
+
+    Buffers[2].pvBuffer = message.data() + stream_sizes().cbHeader + size_encrypted;
+    Buffers[2].cbBuffer = stream_sizes().cbTrailer;
+    Buffers[2].BufferType = SECBUFFER_STREAM_TRAILER;
+
+    Buffers[3].pvBuffer = SECBUFFER_EMPTY;
+    Buffers[3].cbBuffer = SECBUFFER_EMPTY;
+    Buffers[3].BufferType = SECBUFFER_EMPTY;
+
+    Message.ulVersion = SECBUFFER_VERSION;
+    Message.cBuffers = 4;
+    Message.pBuffers = Buffers;
+    SECURITY_STATUS sc = detail::sspi_functions::EncryptMessage(m_context, 0, &Message, 0);
+
+    if (sc != SEC_E_OK) {
+      ec = error::make_error_code(sc);
+      return {};
+    }
+    return message;
+  }
+
+  SECURITY_STATUS decrypt(const std::vector<char>& data) {
+    encrypted_data.insert(encrypted_data.end(), data.begin(), data.end());
+
+    SecBufferDesc Message;
+    SecBuffer Buffers[4];
+
+    Buffers[0].pvBuffer = encrypted_data.data();
+    Buffers[0].cbBuffer = static_cast<ULONG>(encrypted_data.size());
+    Buffers[0].BufferType = SECBUFFER_DATA;
+    Buffers[1].BufferType = SECBUFFER_EMPTY;
+    Buffers[2].BufferType = SECBUFFER_EMPTY;
+    Buffers[3].BufferType = SECBUFFER_EMPTY;
+
+    Message.ulVersion = SECBUFFER_VERSION;
+    Message.cBuffers = 4;
+    Message.pBuffers = Buffers;
+
+    SECURITY_STATUS sc = detail::sspi_functions::DecryptMessage(m_context, &Message, 0, NULL);
+    if (sc != SEC_E_OK) {
+      return sc;
+    }
+
+    encrypted_data.clear();
+    for (int i = 1; i < 4; i++) {
+      if (Buffers[i].BufferType == SECBUFFER_DATA) {
+        SecBuffer* pDataBuffer = &Buffers[i];
+        decrypted_data = std::vector<char>(reinterpret_cast<const char*>(pDataBuffer->pvBuffer), reinterpret_cast<const char*>(pDataBuffer->pvBuffer) + pDataBuffer->cbBuffer);
+      }
+      if (Buffers[i].BufferType == SECBUFFER_EXTRA) {
+        SecBuffer* pExtraBuffer = &Buffers[i];
+        encrypted_data = std::vector<char>(reinterpret_cast<const char*>(pExtraBuffer->pvBuffer), reinterpret_cast<const char*>(pExtraBuffer->pvBuffer) + pExtraBuffer->cbBuffer);
+      }
+    }
+    return sc;
+  }
+
+  std::vector<char> encrypted_data;
+  std::vector<char> decrypted_data;
+
+private:
+  CtxtHandle* m_context;
+};
+
+} // namespace detail
+} // namespace windows_sspi
+} // namespace boost
+
+#endif // BOOST_WINDOWS_SSPI_DETAIL_SSPI_IMPL_HPP

--- a/include/boost/windows_sspi/stream.hpp
+++ b/include/boost/windows_sspi/stream.hpp
@@ -81,9 +81,7 @@ template <typename NextLayer, typename MutableBufferSequence> struct async_read_
       while(m_sspi_impl.decrypt() == detail::sspi_decrypt::state::data_needed) {
         // TODO: Use a fixed size buffer instead
         m_input.resize(0x10000);
-        BOOST_ASIO_CORO_YIELD net::async_read(m_next_layer,
-                                              net::buffer(m_input),
-                                              std::move(self));
+        BOOST_ASIO_CORO_YIELD m_next_layer.async_read_some(net::buffer(m_input), std::move(self));
         m_sspi_impl.decrypt.put({m_input.begin(), m_input.begin() + length});
         m_input.clear();
         continue;

--- a/include/boost/windows_sspi/stream.hpp
+++ b/include/boost/windows_sspi/stream.hpp
@@ -32,8 +32,6 @@
 namespace boost {
 namespace windows_sspi {
 
-namespace net = boost::asio;
-
 // TODO: Move away from this file
 template <typename NextLayer, typename ConstBufferSequence> struct async_write_impl : boost::asio::coroutine {
   async_write_impl(NextLayer& next_layer, const ConstBufferSequence& buffer, std::shared_ptr<detail::sspi_impl> sspi_impl)

--- a/include/boost/windows_sspi/stream.hpp
+++ b/include/boost/windows_sspi/stream.hpp
@@ -90,7 +90,7 @@ template <typename NextLayer, typename MutableBufferSequence> struct async_read_
       }
 
       if (m_sspi_impl.decrypt() == detail::sspi_decrypt::state::error) {
-        ec = boost::error::make_error_code(m_sspi_impl.decrypt.error_code);
+        ec = boost::error::make_error_code(m_sspi_impl.decrypt.last_error);
         self.complete(ec, 0);
         return;
       }
@@ -267,7 +267,7 @@ public:
     }
 
     if (m_sspi_impl.decrypt() == detail::sspi_decrypt::state::error) {
-      ec = boost::error::make_error_code(m_sspi_impl.decrypt.error_code);
+      ec = boost::error::make_error_code(m_sspi_impl.decrypt.last_error);
       return 0;
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,20 +20,6 @@ add_custom_target(
   DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/test_server.key ${CMAKE_CURRENT_BINARY_DIR}/test_server.cert
   )
 
-if (WIN32)
-  add_custom_command(OUTPUT "$ENV{userprofile}/.rnd"
-    COMMAND openssl rand -out "$ENV{userprofile}/.rnd"
-    VERBATIM
-    )
-
-  add_custom_target(
-    generate-random
-    DEPENDS "$ENV{userprofile}/.rnd"
-    )
-
-  add_dependencies(generate-certificate generate-random)
-endif()
-
 add_executable(unittest echo_test.cpp)
 
 add_dependencies(unittest generate-certificate)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,7 +22,7 @@ add_custom_target(
 
 if (WIN32)
   add_custom_command(OUTPUT "$ENV{userprofile}/.rnd"
-    COMMAND openssl rand -writerand "$ENV{userprofile}/.rnd"
+    COMMAND openssl rand -out "$ENV{userprofile}/.rnd"
     VERBATIM
     )
 

--- a/test/echo_test.cpp
+++ b/test/echo_test.cpp
@@ -12,9 +12,20 @@
 
 namespace net = boost::asio;
 
+namespace {
+std::string generate_data(std::size_t size) {
+  std::string ret(size, '\0');
+  for (auto i = 0; i < size - 1; ++i) {
+  const char cur_char = i % 26;
+    ret[i] = cur_char + 65;
+  }
+  return ret;
+}
+}
+
 template<typename ClientTLSContext, typename ClientTLSStream, typename ClientTLSStreamBase>
-void sync_echo_test() {
-  const std::string test_data("Hello world");
+void sync_echo_test(std::size_t test_data_size) {
+  const std::string test_data = generate_data(test_data_size);
   net::io_context io_context;
 
   ClientTLSContext client_ctx(ClientTLSContext::tls_client);
@@ -39,17 +50,27 @@ void sync_echo_test() {
 
   net::write(client_stream, net::buffer(test_data));
 
-  std::array<char, 1024> data;
-  size_t reply_length = server_stream.read_some(net::buffer(data));
+  net::streambuf server_data;
+  net::read_until(server_stream, server_data, '\0');
+  net::write(server_stream, server_data);
 
-  BOOST_TEST_EQ(std::string(data.data(), reply_length), test_data);
+  net::streambuf client_data;
+  net::read_until(client_stream, client_data, '\0');
+
+  BOOST_TEST_EQ(std::string(net::buffers_begin(client_data.data()), net::buffers_begin(client_data.data()) + client_data.size()), test_data);
 }
 
 int main() {
   using test_stream = boost::beast::test::stream;
+  for (const auto size : std::vector<std::size_t>{
+      0x100, 0x100 - 1, 0x100 + 1,
+      0x1000, 0x1000 - 1, 0x1000 + 1,
+      0x10000, 0x10000 - 1, 0x10000 + 1,
+      0x100000, 0x100000 - 1, 0x100000 + 1}) {
 #ifdef _WIN32
-  sync_echo_test<boost::windows_sspi::context, boost::windows_sspi::stream<test_stream>, boost::windows_sspi::stream_base>();
+    sync_echo_test<boost::windows_sspi::context, boost::windows_sspi::stream<test_stream>, boost::windows_sspi::stream_base>(size);
 #endif
-  sync_echo_test<boost::asio::ssl::context, boost::asio::ssl::stream<test_stream>, boost::asio::ssl::stream_base>();
+    sync_echo_test<boost::asio::ssl::context, boost::asio::ssl::stream<test_stream>, boost::asio::ssl::stream_base>(size);
+  }
   return boost::report_errors();
 }


### PR DESCRIPTION
This is a few commits so the branch name is not really descriptive.

Apart from extending the unit test to actually test that the data being sent is the same as being received, this is an attempt towards an actual design where the decryption and encryption is handled by classes that manages state and buffers.

The next thing to do is to extend the tests to test the async implementation and then make the handshake async or implement async handshake and then test it. Whatever makes most sense.

I would really like some feedback on whether the design is moving in the right direction.