### PR TITLE
Async handshake

### DIFF
--- a/examples/https_client.cpp
+++ b/examples/https_client.cpp
@@ -37,26 +37,28 @@ public:
     // TODO: Consider async connect
     net::connect(socket_.next_layer(), endpoint_iterator);
 
-    // TODO: Implement async handshake
-    boost::system::error_code ec;
-    socket_.handshake(ssl::stream_base::client, ec);
-
-    std::ostream request_stream(&request_);
-    request_stream << "GET " << path << " HTTP/1.0\r\n";
-    request_stream << "Host: " << host << "\r\n";
-    request_stream << "Accept: */*\r\n";
-    request_stream << "Connection: close\r\n\r\n";
-
-    boost::asio::async_write(socket_, request_, [this](const boost::system::error_code& ec, std::size_t) {
+    socket_.async_handshake(ssl::stream_base::client, [this, &path, &host](const boost::system::error_code& ec) {
       if (ec) {
-        std::cerr << "Error sending: request:" << ec.message() << "\n";
+        std::cerr << "Error handshaking:" << ec.message() << "\n";
         return;
       }
-      net::async_read_until(socket_, response_, "\r\n", [this](boost::system::error_code ec, size_t) {
+      std::ostream request_stream(&request_);
+      request_stream << "GET " << path << " HTTP/1.0\r\n";
+      request_stream << "Host: " << host << "\r\n";
+      request_stream << "Accept: */*\r\n";
+      request_stream << "Connection: close\r\n\r\n";
+
+      boost::asio::async_write(socket_, request_, [this](const boost::system::error_code& ec, std::size_t) {
         if (ec) {
-          std::cerr << "Error receiving response: " << ec.message() << "\n";
+          std::cerr << "Error sending request:" << ec.message() << "\n";
+          return;
         }
-        read_response();
+        net::async_read_until(socket_, response_, "\r\n", [this](boost::system::error_code ec, size_t) {
+          if (ec) {
+            std::cerr << "Error receiving response: " << ec.message() << "\n";
+          }
+          read_response();
+        });
       });
     });
   }

--- a/examples/https_client.cpp
+++ b/examples/https_client.cpp
@@ -38,7 +38,8 @@ public:
     net::connect(socket_.next_layer(), endpoint_iterator);
 
     // TODO: Implement async handshake
-    socket_.handshake(ssl::stream_base::client);
+    boost::system::error_code ec;
+    socket_.handshake(ssl::stream_base::client, ec);
 
     std::ostream request_stream(&request_);
     request_stream << "GET " << path << " HTTP/1.0\r\n";

--- a/examples/https_client.cpp
+++ b/examples/https_client.cpp
@@ -46,7 +46,6 @@ public:
       request_stream << "GET " << path << " HTTP/1.0\r\n";
       request_stream << "Host: " << host << "\r\n";
       request_stream << "Accept: */*\r\n";
-      request_stream << "Connection: close\r\n\r\n";
 
       boost::asio::async_write(socket_, request_, [this](const boost::system::error_code& ec, std::size_t) {
         if (ec) {

--- a/include/boost/windows_sspi/context.hpp
+++ b/include/boost/windows_sspi/context.hpp
@@ -23,11 +23,15 @@ namespace windows_sspi {
 
 class context : public context_base {
 public:
-  using native_handle_type = CredHandle;
+  using native_handle_type = CredHandle*;
   using error_code = boost::system::error_code;
 
   explicit context(method m)
     : m_impl(std::make_shared<impl>(m)) {
+  }
+
+  native_handle_type native_handle() const {
+    return &m_impl->handle;
   }
 
 private:

--- a/include/boost/windows_sspi/detail/sspi_impl.hpp
+++ b/include/boost/windows_sspi/detail/sspi_impl.hpp
@@ -380,6 +380,9 @@ public:
     , decrypt(&m_context) {
   }
 
+  sspi_impl(const sspi_impl&) = delete;
+  sspi_impl& operator=(const sspi_impl&) = delete;
+
   ~sspi_impl() {
     detail::sspi_functions::DeleteSecurityContext(&m_context);
   }

--- a/include/boost/windows_sspi/stream.hpp
+++ b/include/boost/windows_sspi/stream.hpp
@@ -88,11 +88,12 @@ template <typename NextLayer, typename MutableBufferSequence> struct async_read_
       }
 
       if (m_sspi_impl.decrypt() == detail::sspi_decrypt::state::error) {
-        ec = boost::error::make_error_code(m_sspi_impl.decrypt.last_error);
+        ec = m_sspi_impl.decrypt.last_error();
         self.complete(ec, 0);
         return;
       }
 
+      // TODO: Avoid this copy if possible
       const auto data = m_sspi_impl.decrypt.get(net::buffer_size(m_buffers));
       std::size_t bytes_copied = net::buffer_copy(m_buffers, net::buffer(data));
       BOOST_ASSERT(bytes_copied == data.size());
@@ -116,11 +117,7 @@ public:
   stream(Arg&& arg, context& ctx)
     : stream_base(ctx)
     , m_next_layer(std::forward<Arg>(arg))
-    , m_sspi_impl(&m_security_context) {
-  }
-
-  ~stream() {
-    detail::sspi_functions::DeleteSecurityContext(&m_security_context);
+    , m_sspi_impl(ctx.native_handle()) {
   }
 
   const next_layer_type& next_layer() const {
@@ -131,141 +128,51 @@ public:
     return m_next_layer;
   }
 
-  void handshake(handshake_type type) {
-    DWORD flags_out = 0;
-    DWORD flags_in = ISC_REQ_SEQUENCE_DETECT | ISC_REQ_REPLAY_DETECT | ISC_REQ_CONFIDENTIALITY |
-                     ISC_RET_EXTENDED_ERROR | ISC_REQ_ALLOCATE_MEMORY | ISC_REQ_STREAM;
-
-    boost::system::error_code ec;
-    SECURITY_STATUS sc = SEC_E_OK;
-
-    SecBufferDesc OutBuffer;
-    SecBuffer OutBuffers[1];
-    SecBufferDesc InBuffer;
-    SecBuffer InBuffers[2];
-
-    if (type == client) {
-      OutBuffers[0].pvBuffer = NULL;
-      OutBuffers[0].BufferType = SECBUFFER_TOKEN;
-      OutBuffers[0].cbBuffer = 0;
-
-      OutBuffer.cBuffers = 1;
-      OutBuffer.pBuffers = OutBuffers;
-      OutBuffer.ulVersion = SECBUFFER_VERSION;
-
-      sc = detail::sspi_functions::InitializeSecurityContext(&m_context_impl->handle,
-                                                             NULL,
-                                                             NULL,
-                                                             flags_in,
-                                                             0,
-                                                             SECURITY_NATIVE_DREP,
-                                                             NULL,
-                                                             0,
-                                                             &m_security_context,
-                                                             &OutBuffer,
-                                                             &flags_out,
-                                                             NULL);
-      if (sc != SEC_I_CONTINUE_NEEDED) {
-        throw boost::system::system_error(error::make_error_code(sc), "InitializeSecurityContext");
-      }
-
-      size_t size_written = m_next_layer.write_some(net::const_buffer(OutBuffers[0].pvBuffer, OutBuffers[0].cbBuffer), ec);
-      boost::ignore_unused(size_written);
-      BOOST_ASSERT(size_written == OutBuffers[0].cbBuffer);
-      detail::sspi_functions::FreeContextBuffer(OutBuffers[0].pvBuffer);
-      if (ec) {
-        throw boost::system::system_error(ec);
-      }
-    }
-
-    size_t input_size = 0;
-    std::array<char, 0x10000> buffer;
-
-    while (true) {
-      input_size += m_next_layer.read_some(net::buffer(buffer.data() + input_size, buffer.size() - input_size), ec);
-      if (ec) {
-        throw boost::system::system_error(ec);
-      }
-
-      InBuffers[0].pvBuffer = reinterpret_cast<void*>(buffer.data());
-      InBuffers[0].cbBuffer = static_cast<ULONG>(input_size);
-      InBuffers[0].BufferType = SECBUFFER_TOKEN;
-
-      InBuffers[1].pvBuffer = NULL;
-      InBuffers[1].cbBuffer = 0;
-      InBuffers[1].BufferType = SECBUFFER_EMPTY;
-
-      InBuffer.cBuffers = 2;
-      InBuffer.pBuffers = InBuffers;
-      InBuffer.ulVersion = SECBUFFER_VERSION;
-
-      OutBuffers[0].pvBuffer = NULL;
-      OutBuffers[0].BufferType = SECBUFFER_TOKEN;
-      OutBuffers[0].cbBuffer = 0;
-
-      OutBuffer.cBuffers = 1;
-      OutBuffer.pBuffers = OutBuffers;
-      OutBuffer.ulVersion = SECBUFFER_VERSION;
-
-      sc = detail::sspi_functions::InitializeSecurityContext(&m_context_impl->handle,
-                                                             &m_security_context,
-                                                             NULL,
-                                                             flags_in,
-                                                             0,
-                                                             SECURITY_NATIVE_DREP,
-                                                             &InBuffer,
-                                                             0,
-                                                             NULL,
-                                                             &OutBuffer,
-                                                             &flags_out,
-                                                             NULL);
-
-      if (OutBuffers[0].cbBuffer != 0 && OutBuffers[0].pvBuffer != NULL) {
-        m_next_layer.write_some(net::const_buffer(OutBuffers[0].pvBuffer, OutBuffers[0].cbBuffer), ec);
-        detail::sspi_functions::FreeContextBuffer(OutBuffers[0].pvBuffer);
-        OutBuffers[0].pvBuffer = NULL;
-        if (ec) {
-          throw boost::system::system_error(ec);
-        }
-      }
-
-      switch (sc) {
-      case SEC_E_INCOMPLETE_MESSAGE:
-        continue;
-
-      case SEC_E_OK:
-        BOOST_ASSERT_MSG(InBuffers[1].BufferType != SECBUFFER_EXTRA, "Handle extra data from handshake");
-        return;
-
-      case SEC_I_INCOMPLETE_CREDENTIALS:
-        BOOST_ASSERT_MSG(false, "client authentication not implemented");
-
-      default:
-        if (FAILED(sc)) {
-          throw boost::system::system_error(error::make_error_code(sc), "InitializeSecurityContext");
-        }
-      }
-
-      if (InBuffers[1].BufferType == SECBUFFER_EXTRA) {
-        std::copy_n(buffer.data() + (input_size - InBuffers[1].cbBuffer), InBuffers[1].cbBuffer, buffer.data());
-        input_size = InBuffers[1].cbBuffer;
-      } else {
-        input_size = 0;
+  void handshake(handshake_type, boost::system::error_code& ec) {
+    detail::sspi_handshake::state state;
+    while((state = m_sspi_impl.handshake()) != detail::sspi_handshake::state::done) {
+      switch (state) {
+        case detail::sspi_handshake::state::data_needed:
+          {
+            std::array<char, 0x10000> input_buffer;
+            std::size_t size_read = m_next_layer.read_some(net::buffer(input_buffer.data(), input_buffer.size()), ec);
+            if (ec) {
+              return;
+            }
+            m_sspi_impl.handshake.put({input_buffer.begin(), input_buffer.begin() + size_read});
+            continue;
+          }
+        case detail::sspi_handshake::state::data_available:
+          {
+            auto data = m_sspi_impl.handshake.get();
+            net::write(m_next_layer, net::buffer(data), net::transfer_exactly(data.size()), ec);
+            if (ec) {
+              return;
+            }
+            continue;
+          }
+        case detail::sspi_handshake::state::error:
+          ec = m_sspi_impl.handshake.last_error();
+          return;
       }
     }
   }
 
   template <typename MutableBufferSequence>
   size_t read_some(const MutableBufferSequence& buffers, boost::system::error_code& ec) {
-    while(m_sspi_impl.decrypt() == detail::sspi_decrypt::state::data_needed) {
+    detail::sspi_decrypt::state state;
+    while((state = m_sspi_impl.decrypt()) == detail::sspi_decrypt::state::data_needed) {
       std::array<char, 0x10000> input_buffer;
       std::size_t size_read = m_next_layer.read_some(net::buffer(input_buffer.data(), input_buffer.size()), ec);
+      if (ec) {
+        return 0;
+      }
       m_sspi_impl.decrypt.put({input_buffer.begin(), input_buffer.begin() + size_read});
       continue;
     }
 
-    if (m_sspi_impl.decrypt() == detail::sspi_decrypt::state::error) {
-      ec = boost::error::make_error_code(m_sspi_impl.decrypt.last_error);
+    if (state == detail::sspi_decrypt::state::error) {
+      ec = m_sspi_impl.decrypt.last_error();
       return 0;
     }
 
@@ -291,7 +198,6 @@ public:
     }
 
     net::write(m_next_layer, net::buffer(m_sspi_impl.encrypt.data()), net::transfer_exactly(m_sspi_impl.encrypt.data().size()), ec);
-
     if (ec) {
       return 0;
     }
@@ -309,7 +215,6 @@ public:
 
 private:
   next_layer_type m_next_layer;
-  CtxtHandle m_security_context;
   detail::sspi_impl m_sspi_impl;
 };
 

--- a/test/async_echo_client.hpp
+++ b/test/async_echo_client.hpp
@@ -1,0 +1,49 @@
+#include <boost/asio.hpp>
+
+template<typename TLSContext, typename TLSStream, typename TLSStreamBase>
+class async_client {
+public:
+  async_client(TLSStream& stream, TLSContext& context, const std::string& message)
+    : m_context(context)
+    , m_stream(stream)
+    , m_message(message) {
+    do_handshake();
+  }
+
+  void do_handshake() {
+    m_stream.async_handshake(TLSStreamBase::client,
+                             [this](const boost::system::error_code& ec) {
+                               if (!ec) {
+                                 do_write();
+                               }
+                             });
+  }
+
+  void do_write() {
+    boost::asio::async_write(m_stream, boost::asio::buffer(m_message),
+                             [this](const boost::system::error_code& ec, std::size_t) {
+                               if (!ec) {
+                                 do_read();
+                               }
+                             });
+}
+
+  void do_read() {
+    boost::asio::async_read_until(m_stream, m_received_message, '\0',
+                                  [this](const boost::system::error_code& ec, std::size_t) {
+                                    if (!ec) {
+                                    }
+                                  });
+  }
+
+  std::string received_message() const {
+    return std::string(boost::asio::buffers_begin(m_received_message.data()),
+                       boost::asio::buffers_begin(m_received_message.data()) + m_received_message.size());
+  }
+
+private:
+  TLSContext& m_context;
+  TLSStream& m_stream;
+  std::string m_message;
+  boost::asio::streambuf m_received_message;
+};

--- a/test/async_echo_server.hpp
+++ b/test/async_echo_server.hpp
@@ -1,0 +1,40 @@
+#include <boost/asio.hpp>
+
+template<typename TLSContext, typename TLSStream, typename TLSStreamBase>
+class async_server {
+public:
+  async_server(TLSStream& stream, TLSContext& context)
+    : m_context(context)
+    , m_stream(stream) {
+    do_handshake();
+  }
+
+  void do_handshake() {
+    m_stream.async_handshake(TLSStreamBase::server,
+                             [this](const boost::system::error_code& ec) {
+                               if (!ec) {
+                                 do_read();
+                               }
+                             });
+  }
+
+  void do_read() {
+    boost::asio::async_read_until(m_stream, m_data, '\0',
+                                  [this](const boost::system::error_code& ec, std::size_t) {
+                                    if (!ec) {
+                                      do_write();
+                                    }
+                                  });
+  }
+
+  void do_write() {
+    boost::asio::async_write(m_stream, m_data,
+                             [this](const boost::system::error_code&, std::size_t) {
+                             });
+  }
+
+private:
+  TLSContext& m_context;
+  TLSStream& m_stream;
+  boost::asio::streambuf m_data;
+};

--- a/test/echo_test.cpp
+++ b/test/echo_test.cpp
@@ -78,7 +78,9 @@ void sync_echo_test(std::size_t test_data_size) {
   std::thread server_handshake([&server_stream]() {
     server_stream.handshake(boost::asio::ssl::stream_base::server);
   });
-  client_stream.handshake(ClientTLSStreamBase::client);
+  boost::system::error_code ec;
+  client_stream.handshake(ClientTLSStreamBase::client, ec);
+  BOOST_TEST_NOT(ec);
   server_handshake.join();
 
   net::write(client_stream, net::buffer(test_data));
@@ -106,5 +108,6 @@ int main() {
     sync_echo_test<boost::asio::ssl::context, boost::asio::ssl::stream<test_stream>, boost::asio::ssl::stream_base>(size);
     async_echo_test<boost::asio::ssl::context, boost::asio::ssl::stream<test_stream>, boost::asio::ssl::stream_base>(size);
   }
+
   return boost::report_errors();
 }

--- a/test/echo_test.cpp
+++ b/test/echo_test.cpp
@@ -1,3 +1,6 @@
+#include "async_echo_server.hpp"
+#include "async_echo_client.hpp"
+
 #include <boost/core/lightweight_test.hpp>
 #include <boost/beast/_experimental/test/stream.hpp>
 #include <boost/asio.hpp>
@@ -21,6 +24,36 @@ std::string generate_data(std::size_t size) {
   }
   return ret;
 }
+}
+
+template<typename ClientTLSContext, typename ClientTLSStream, typename ClientTLSStreamBase>
+void async_echo_test(std::size_t test_data_size) {
+  const std::string test_data = generate_data(test_data_size);
+  net::io_context io_context;
+
+  ClientTLSContext client_ctx(ClientTLSContext::tls_client);
+
+  boost::asio::ssl::context server_ctx(boost::asio::ssl::context::tls_server);
+  server_ctx.use_certificate_chain_file(TEST_CERTIFICATE_PATH);
+  server_ctx.use_private_key_file(TEST_PRIVATE_KEY_PATH, boost::asio::ssl::context::pem);
+
+  ClientTLSStream client_stream(io_context, client_ctx);
+  boost::asio::ssl::stream<boost::beast::test::stream> server_stream(io_context, server_ctx);
+
+  client_stream.next_layer().connect(server_stream.next_layer());
+
+  async_server<boost::asio::ssl::context,
+               boost::asio::ssl::stream<boost::beast::test::stream>,
+               boost::asio::ssl::stream_base>
+    server(server_stream, server_ctx);
+
+  async_client<boost::asio::ssl::context,
+               boost::asio::ssl::stream<boost::beast::test::stream>,
+               boost::asio::ssl::stream_base>
+    client(client_stream, client_ctx, test_data);
+
+  io_context.run();
+  BOOST_TEST_EQ(client.received_message(), test_data);
 }
 
 template<typename ClientTLSContext, typename ClientTLSStream, typename ClientTLSStreamBase>
@@ -71,6 +104,7 @@ int main() {
     sync_echo_test<boost::windows_sspi::context, boost::windows_sspi::stream<test_stream>, boost::windows_sspi::stream_base>(size);
 #endif
     sync_echo_test<boost::asio::ssl::context, boost::asio::ssl::stream<test_stream>, boost::asio::ssl::stream_base>(size);
+    async_echo_test<boost::asio::ssl::context, boost::asio::ssl::stream<test_stream>, boost::asio::ssl::stream_base>(size);
   }
   return boost::report_errors();
 }

--- a/test/echo_test.cpp
+++ b/test/echo_test.cpp
@@ -47,9 +47,9 @@ void async_echo_test(std::size_t test_data_size) {
                boost::asio::ssl::stream_base>
     server(server_stream, server_ctx);
 
-  async_client<boost::asio::ssl::context,
-               boost::asio::ssl::stream<boost::beast::test::stream>,
-               boost::asio::ssl::stream_base>
+  async_client<ClientTLSContext,
+               ClientTLSStream,
+               ClientTLSStreamBase>
     client(client_stream, client_ctx, test_data);
 
   io_context.run();
@@ -104,6 +104,7 @@ int main() {
       0x100000, 0x100000 - 1, 0x100000 + 1}) {
 #ifdef _WIN32
     sync_echo_test<boost::windows_sspi::context, boost::windows_sspi::stream<test_stream>, boost::windows_sspi::stream_base>(size);
+    async_echo_test<boost::windows_sspi::context, boost::windows_sspi::stream<test_stream>, boost::windows_sspi::stream_base>(size);
 #endif
     sync_echo_test<boost::asio::ssl::context, boost::asio::ssl::stream<test_stream>, boost::asio::ssl::stream_base>(size);
     async_echo_test<boost::asio::ssl::context, boost::asio::ssl::stream<test_stream>, boost::asio::ssl::stream_base>(size);


### PR DESCRIPTION
This implements async handshake which means that most of the basic functionality has been implemented on the client side. The goal being to implement all of the functionality available in the existing `boost::asio::ssl` implementation.

I intend to extend the tests to test errors, short read/writes etc. which should thankfully be fairly easy to achieve using the convenient test stream from `boost::beast`. There are quite a few places where some buffer copies could be avoided and definitely quite a lot of other things that could and should be cleaned up, but I think that will be easier to do once I have extended the tests a bit.

I also need to look into implementing the server side functionality, which mainly means implementing server handshake as well as all the certificate handling.