### PR TITLE
Shutdown

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,6 +20,9 @@ environment:
 before_build:
   - cmake -H. -B./build -T "%TOOLSET%" -DBOOST_ROOT="C:/Libraries/boost_1_73_0"
 
+build:
+  project: build/boost-windows-sspi.sln
+
 test_script:
   - cd build
   - ctest -C %CONFIGURATION% --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,11 +70,11 @@ endif()
 
 if(ENABLE_TESTING)
   enable_testing()
-  message("Building Tests.")
+  message(STATUS "Building Tests.")
   add_subdirectory(test)
 endif()
 
 if(ENABLE_EXAMPLES)
-  message("Building Examples.")
+  message(STATUS "Building Examples.")
   add_subdirectory(examples)
 endif()

--- a/include/boost/windows_sspi/detail/sspi_functions.hpp
+++ b/include/boost/windows_sspi/detail/sspi_functions.hpp
@@ -91,8 +91,12 @@ inline SECURITY_STATUS EncryptMessage(PCtxtHandle phContext, unsigned long fQOP,
   return sspi_function_table()->EncryptMessage(phContext, fQOP, pMessage, MessageSeqNo);
 }
 
-inline SECURITY_STATUS SEC_ENTRY FreeCredentialsHandle(PCredHandle phCredential) {
+inline SECURITY_STATUS FreeCredentialsHandle(PCredHandle phCredential) {
   return sspi_function_table()->FreeCredentialsHandle(phCredential);
+}
+
+inline SECURITY_STATUS ApplyControlToken(PCtxtHandle phContext, PSecBufferDesc pInput) {
+  return sspi_function_table()->ApplyControlToken(phContext, pInput);
 }
 
 } // namespace sspi_functions

--- a/include/boost/windows_sspi/error.hpp
+++ b/include/boost/windows_sspi/error.hpp
@@ -96,7 +96,7 @@ public:
   }
 };
 
-boost::system::error_category& get_sspi_category() {
+inline boost::system::error_category& get_sspi_category() {
   static error_category instance;
   return instance;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,5 @@
+Include(FetchContent)
+
 if (NOT OPENSSL_FOUND)
   message(SEND_ERROR "OpenSSL not found. Cannot build tests.")
   return()
@@ -20,7 +22,18 @@ add_custom_target(
   DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/test_server.key ${CMAKE_CURRENT_BINARY_DIR}/test_server.cert
   )
 
-add_executable(unittest echo_test.cpp)
+FetchContent_Declare(
+  Catch2
+  GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+  GIT_TAG        v2.13.1) # TODO: Use latest
+
+FetchContent_MakeAvailable(Catch2)
+list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/contrib)
+
+add_executable(unittest
+  main.cpp
+  echo_test.cpp
+  )
 
 add_dependencies(unittest generate-certificate)
 
@@ -33,6 +46,7 @@ target_link_libraries(unittest PRIVATE
   OpenSSL::SSL
   OpenSSL::Crypto
   Threads::Threads
+  Catch2::Catch2
   )
 
 if (WIN32)
@@ -41,4 +55,6 @@ if (WIN32)
     )
 endif()
 
-add_test(NAME unittest COMMAND unittest)
+include(CTest)
+include(Catch)
+catch_discover_tests(unittest)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,14 +25,25 @@ add_custom_target(
 FetchContent_Declare(
   Catch2
   GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-  GIT_TAG        v2.13.1) # TODO: Use latest
+  GIT_TAG        v2.13.2)
 
 FetchContent_MakeAvailable(Catch2)
 list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/contrib)
 
-add_executable(unittest
+set(test_sources
   main.cpp
   echo_test.cpp
+  tls_record.cpp
+  )
+
+if (WIN32)
+  list(APPEND test_sources
+    handshake_test.cpp
+    )
+endif()
+
+add_executable(unittest
+  ${test_sources}
   )
 
 add_dependencies(unittest generate-certificate)

--- a/test/async_echo_client.hpp
+++ b/test/async_echo_client.hpp
@@ -1,3 +1,6 @@
+#ifndef BOOST_WINDOWS_SSPI_TEST_ASYNC_ECHO_CLIENT
+#define BOOST_WINDOWS_SSPI_TEST_ASYNC_ECHO_CLIENT
+
 #include <boost/asio.hpp>
 
 template<typename TLSContext, typename TLSStream, typename TLSStreamBase>
@@ -55,3 +58,5 @@ private:
   std::string m_message;
   boost::asio::streambuf m_received_message;
 };
+
+#endif

--- a/test/async_echo_client.hpp
+++ b/test/async_echo_client.hpp
@@ -26,14 +26,22 @@ public:
                                  do_read();
                                }
                              });
-}
+  }
 
   void do_read() {
     boost::asio::async_read_until(m_stream, m_received_message, '\0',
-                                  [](const boost::system::error_code& ec, std::size_t) {
+                                  [this](const boost::system::error_code& ec, std::size_t) {
                                     if (!ec) {
+                                      do_shutdown();
                                     }
                                   });
+  }
+
+  void do_shutdown() {
+    m_stream.async_shutdown([](const boost::system::error_code& ec) {
+      if (!ec) {
+      }
+    });
   }
 
   std::string received_message() const {

--- a/test/async_echo_server.hpp
+++ b/test/async_echo_server.hpp
@@ -29,8 +29,18 @@ public:
 
   void do_write() {
     boost::asio::async_write(m_stream, m_data,
-                             [](const boost::system::error_code&, std::size_t) {
+                             [this](const boost::system::error_code& ec, std::size_t) {
+                               if (!ec) {
+                                 do_shutdown();
+                               }
                              });
+  }
+
+  void do_shutdown() {
+    m_stream.async_shutdown([](const boost::system::error_code& ec) {
+      if (!ec) {
+      }
+    });
   }
 
 private:

--- a/test/async_echo_server.hpp
+++ b/test/async_echo_server.hpp
@@ -1,3 +1,6 @@
+#ifndef BOOST_WINDOWS_SSPI_TEST_ASYNC_ECHO_SERVER
+#define BOOST_WINDOWS_SSPI_TEST_ASYNC_ECHO_SERVER
+
 #include <boost/asio.hpp>
 
 template<typename TLSContext, typename TLSStream, typename TLSStreamBase>
@@ -48,3 +51,5 @@ private:
   TLSStream& m_stream;
   boost::asio::streambuf m_data;
 };
+
+#endif

--- a/test/echo_test.cpp
+++ b/test/echo_test.cpp
@@ -1,19 +1,24 @@
 #include "async_echo_server.hpp"
 #include "async_echo_client.hpp"
 
-#include <boost/core/lightweight_test.hpp>
-#include <boost/beast/_experimental/test/stream.hpp>
-#include <boost/asio.hpp>
-#include <boost/asio/ssl.hpp>
-
 #ifdef _WIN32
 #include <boost/windows_sspi/windows_sspi.hpp>
 #endif
 
-#include <array>
+#include <catch2/catch.hpp>
+
+#include <boost/beast/_experimental/test/stream.hpp>
+#include <boost/asio.hpp>
+#include <boost/asio/ssl.hpp>
+
+#include <string>
 #include <thread>
+#include <tuple>
+#include <cstdint>
 
 namespace net = boost::asio;
+namespace asio_ssl = boost::asio::ssl;
+using test_stream = boost::beast::test::stream;
 
 namespace {
 std::string generate_data(std::size_t size) {
@@ -26,99 +31,88 @@ std::string generate_data(std::size_t size) {
 }
 }
 
-template<typename ClientTLSContext, typename ClientTLSStream, typename ClientTLSStreamBase>
-void async_echo_test(std::size_t test_data_size) {
-  const std::string test_data = generate_data(test_data_size);
-  net::io_context io_context;
-
-  ClientTLSContext client_ctx(ClientTLSContext::tls_client);
-
-  boost::asio::ssl::context server_ctx(boost::asio::ssl::context::tls_server);
-  server_ctx.use_certificate_chain_file(TEST_CERTIFICATE_PATH);
-  server_ctx.use_private_key_file(TEST_PRIVATE_KEY_PATH, boost::asio::ssl::context::pem);
-
-  ClientTLSStream client_stream(io_context, client_ctx);
-  boost::asio::ssl::stream<boost::beast::test::stream> server_stream(io_context, server_ctx);
-
-  client_stream.next_layer().connect(server_stream.next_layer());
-
-  async_server<boost::asio::ssl::context,
-               boost::asio::ssl::stream<boost::beast::test::stream>,
-               boost::asio::ssl::stream_base>
-    server(server_stream, server_ctx);
-
-  async_client<ClientTLSContext,
-               ClientTLSStream,
-               ClientTLSStreamBase>
-    client(client_stream, client_ctx, test_data);
-
-  io_context.run();
-  BOOST_TEST_EQ(client.received_message(), test_data);
-}
-
-template<typename ClientTLSContext, typename ClientTLSStream, typename ClientTLSStreamBase>
-void sync_echo_test(std::size_t test_data_size) {
-  const std::string test_data = generate_data(test_data_size);
-  net::io_context io_context;
-
-  ClientTLSContext client_ctx(ClientTLSContext::tls_client);
-
-  boost::asio::ssl::context server_ctx(boost::asio::ssl::context::tls_server);
-  server_ctx.use_certificate_chain_file(TEST_CERTIFICATE_PATH);
-  server_ctx.use_private_key_file(TEST_PRIVATE_KEY_PATH, boost::asio::ssl::context::pem);
-
-  ClientTLSStream client_stream(io_context, client_ctx);
-  boost::asio::ssl::stream<boost::beast::test::stream> server_stream(io_context, server_ctx);
-
-  client_stream.next_layer().connect(server_stream.next_layer());
-
-  // As the handshake requires multiple read and writes between client
-  // and server, we have to run the synchronous version in a separate
-  // thread. Unfortunately.
-  std::thread server_handshake([&server_stream]() {
-    server_stream.handshake(boost::asio::ssl::stream_base::server);
-  });
-  boost::system::error_code ec;
-  client_stream.handshake(ClientTLSStreamBase::client, ec);
-  BOOST_TEST_NOT(ec);
-  server_handshake.join();
-
-  net::write(client_stream, net::buffer(test_data));
-
-  net::streambuf server_data;
-  net::read_until(server_stream, server_data, '\0');
-  net::write(server_stream, server_data);
-
-  net::streambuf client_data;
-  net::read_until(client_stream, client_data, '\0');
-
-  // As a shutdown potentially requires multiple read and writes
-  // between client and server, we have to run the synchronous version
-  // in a separate thread. Unfortunately.
-  std::thread server_shutdown([&server_stream]() {
-    server_stream.shutdown();
-  });
-  client_stream.shutdown(ec);
-  BOOST_TEST_NOT(ec);
-  server_shutdown.join();
-
-  BOOST_TEST_EQ(std::string(net::buffers_begin(client_data.data()), net::buffers_begin(client_data.data()) + client_data.size()), test_data);
-}
-
-int main() {
-  using test_stream = boost::beast::test::stream;
-  for (const auto size : std::vector<std::size_t>{
-      0x100, 0x100 - 1, 0x100 + 1,
-      0x1000, 0x1000 - 1, 0x1000 + 1,
-      0x10000, 0x10000 - 1, 0x10000 + 1,
-      0x100000, 0x100000 - 1, 0x100000 + 1}) {
+using SSLClientTypes = std::tuple<asio_ssl::context, asio_ssl::stream<test_stream>, asio_ssl::stream_base>;
 #ifdef _WIN32
-    sync_echo_test<boost::windows_sspi::context, boost::windows_sspi::stream<test_stream>, boost::windows_sspi::stream_base>(size);
-    async_echo_test<boost::windows_sspi::context, boost::windows_sspi::stream<test_stream>, boost::windows_sspi::stream_base>(size);
+using SSPIClientTypes = std::tuple<boost::windows_sspi::context, boost::windows_sspi::stream<test_stream>, boost::windows_sspi::stream_base>;
 #endif
-    sync_echo_test<boost::asio::ssl::context, boost::asio::ssl::stream<test_stream>, boost::asio::ssl::stream_base>(size);
-    async_echo_test<boost::asio::ssl::context, boost::asio::ssl::stream<test_stream>, boost::asio::ssl::stream_base>(size);
+
+#ifdef _WIN32
+using ClientTypes = std::tuple<SSLClientTypes, SSPIClientTypes>;
+#else
+using ClientTypes = std::tuple<SSLClientTypes>;
+#endif
+
+TEMPLATE_LIST_TEST_CASE("echo test", "", ClientTypes) {
+  static_assert(std::tuple_size<TestType>::value == 3, "Expected exactly three client TLS types");
+  using ClientTLSContext = typename std::tuple_element<0, TestType>::type;
+  using ClientTLSStream = typename std::tuple_element<1, TestType>::type;
+  using ClientTLSStreamBase = typename std::tuple_element<2, TestType>::type;
+
+  auto test_data_size = GENERATE(0x100, 0x100 - 1, 0x100 + 1,
+                                 0x1000, 0x1000 - 1, 0x1000 + 1,
+                                 0x10000, 0x10000 - 1, 0x10000 + 1,
+                                 0x100000, 0x100000 - 1, 0x100000 + 1);
+  const std::string test_data = generate_data(test_data_size);
+
+  ClientTLSContext client_ctx(ClientTLSContext::tls_client);
+
+  boost::asio::ssl::context server_ctx(boost::asio::ssl::context::tls_server);
+  server_ctx.use_certificate_chain_file(TEST_CERTIFICATE_PATH);
+  server_ctx.use_private_key_file(TEST_PRIVATE_KEY_PATH, boost::asio::ssl::context::pem);
+
+  net::io_context io_context;
+  ClientTLSStream client_stream(io_context, client_ctx);
+  boost::asio::ssl::stream<boost::beast::test::stream> server_stream(io_context, server_ctx);
+
+  client_stream.next_layer().connect(server_stream.next_layer());
+
+  SECTION("sync test") {
+    // As the handshake requires multiple read and writes between client
+    // and server, we have to run the synchronous version in a separate
+    // thread. Unfortunately.
+    std::thread server_handshake([&server_stream]() {
+      server_stream.handshake(boost::asio::ssl::stream_base::server);
+    });
+    boost::system::error_code ec;
+    client_stream.handshake(ClientTLSStreamBase::client, ec);
+    REQUIRE_FALSE(ec);
+    server_handshake.join();
+
+    net::write(client_stream, net::buffer(test_data));
+
+    net::streambuf server_data;
+    net::read_until(server_stream, server_data, '\0');
+    net::write(server_stream, server_data);
+
+    net::streambuf client_data;
+    net::read_until(client_stream, client_data, '\0');
+
+    // As a shutdown potentially requires multiple read and writes
+    // between client and server, we have to run the synchronous version
+    // in a separate thread. Unfortunately.
+    std::thread server_shutdown([&server_stream]() {
+      server_stream.shutdown();
+    });
+    client_stream.shutdown(ec);
+    REQUIRE_FALSE(ec);
+    server_shutdown.join();
+
+    CHECK(std::string(net::buffers_begin(client_data.data()),
+                      net::buffers_begin(client_data.data()) + client_data.size()) == test_data);
   }
 
-  return boost::report_errors();
+  SECTION("async test") {
+    async_server<boost::asio::ssl::context,
+                 boost::asio::ssl::stream<boost::beast::test::stream>,
+                 boost::asio::ssl::stream_base>
+      server(server_stream, server_ctx);
+
+    async_client<ClientTLSContext,
+                 ClientTLSStream,
+                 ClientTLSStreamBase>
+      client(client_stream, client_ctx, test_data);
+
+    io_context.run();
+    CHECK(client.received_message() == test_data);
+  }
 }

--- a/test/handshake_test.cpp
+++ b/test/handshake_test.cpp
@@ -1,0 +1,52 @@
+#include "async_echo_server.hpp"
+#include "async_echo_client.hpp"
+#include "tls_record.hpp"
+
+#include <boost/windows_sspi/windows_sspi.hpp>
+
+#include <catch2/catch.hpp>
+
+#include <boost/beast/_experimental/test/stream.hpp>
+#include <boost/asio.hpp>
+#include <boost/asio/ssl.hpp>
+
+namespace net = boost::asio;
+
+TEST_CASE("handshake") {
+  using namespace std::string_literals;
+
+  boost::windows_sspi::context client_ctx(boost::windows_sspi::context::tls_client);
+
+  boost::asio::ssl::context server_ctx(boost::asio::ssl::context::tls_server);
+  server_ctx.use_certificate_chain_file(TEST_CERTIFICATE_PATH);
+  server_ctx.use_private_key_file(TEST_PRIVATE_KEY_PATH, boost::asio::ssl::context::pem);
+
+  net::io_context io_context;
+  boost::windows_sspi::stream<boost::beast::test::stream> client_stream(io_context, client_ctx);
+  boost::asio::ssl::stream<boost::beast::test::stream> server_stream(io_context, server_ctx);
+
+  client_stream.next_layer().connect(server_stream.next_layer());
+
+  SECTION("invalid server reply") {
+    boost::system::error_code error{};
+    client_stream.async_handshake(boost::windows_sspi::stream_base::client,
+                                  [&error](const boost::system::error_code& ec) {
+                                    error = ec;
+                                  });
+
+    std::array<char, 1024> buffer;
+    server_stream.next_layer().async_read_some(net::buffer(buffer, buffer.size()),
+                                               [&buffer, &server_stream](const boost::system::error_code&, std::size_t length) {
+                                                 tls_record rec(net::buffer(buffer, length));
+                                                 REQUIRE(rec.type == tls_record::record_type::handshake);
+                                                 auto handshake = boost::get<tls_handshake>(rec.message);
+                                                 REQUIRE(handshake.type == tls_handshake::handshake_type::client_hello);
+                                                 // Echoing the client_hello message back should cause the handshake to fail
+                                                 net::write(server_stream.next_layer(), net::buffer(buffer));
+                    });
+
+    io_context.run();
+    CHECK(error.category() == boost::windows_sspi::error::get_sspi_category());
+    CHECK(error.value() == SEC_E_ILLEGAL_MESSAGE);
+  }
+}

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>

--- a/test/tls_record.cpp
+++ b/test/tls_record.cpp
@@ -1,0 +1,85 @@
+#include "tls_record.hpp"
+
+namespace {
+std::uint8_t net_to_host(std::uint8_t value) {
+  return value;
+}
+
+std::uint16_t net_to_host(std::uint16_t value) {
+  return ntohs(value);
+}
+
+std::uint32_t net_to_host(std::uint32_t value) {
+  return ntohl(value);
+}
+
+template <typename SizeType>
+SizeType read_value(net::const_buffer& buffer) {
+  BOOST_ASSERT(buffer.size() >= sizeof(SizeType));
+  SizeType ret = *reinterpret_cast<const SizeType*>(buffer.data());
+  buffer += sizeof(SizeType);
+  return net_to_host(ret);
+}
+
+std::uint32_t read_three_byte_value(net::const_buffer& buffer) {
+  BOOST_ASSERT(buffer.size() >= 3);
+  std::array<char, 4> value{};
+  std::copy_n(reinterpret_cast<const char*>(buffer.data()), 3, value.begin() + 1);
+  buffer += 3;
+  return net_to_host(*reinterpret_cast<std::uint32_t*>(value.data()));
+}
+
+tls_record::message_type read_message(tls_record::record_type type, net::const_buffer& buffer) {
+  switch(type) {
+    case tls_record::record_type::change_cipher_spec:
+      return tls_change_cipher_spec{};
+    case tls_record::record_type::alert:
+      return tls_alert{};
+    case tls_record::record_type::handshake:
+      return tls_handshake{buffer};
+    case tls_record::record_type::application_data:
+      return tls_application_data{};
+  }
+  BOOST_UNREACHABLE_RETURN(0);
+}
+
+tls_handshake::message_type read_message(tls_handshake::handshake_type t, net::const_buffer&) {
+  switch(t) {
+    case tls_handshake::handshake_type::hello_request:
+      return tls_handshake::hello_request{};
+    case tls_handshake::handshake_type::client_hello:
+      return tls_handshake::client_hello{};
+    case tls_handshake::handshake_type::server_hello:
+      return tls_handshake::server_hello{};
+    case tls_handshake::handshake_type::certificate:
+      return tls_handshake::certificate{};
+    case tls_handshake::handshake_type::server_key_exchange:
+      return tls_handshake::server_key_exchange{};
+    case tls_handshake::handshake_type::certificate_request:
+      return tls_handshake::certificate_request{};
+    case tls_handshake::handshake_type::server_done:
+      return tls_handshake::server_done{};
+    case tls_handshake::handshake_type::certificate_verify:
+      return tls_handshake::certificate_verify{};
+    case tls_handshake::handshake_type::client_key_exchange:
+      return tls_handshake::client_key_exchange{};
+    case tls_handshake::handshake_type::finished:
+      return tls_handshake::finished{};
+  }
+  BOOST_UNREACHABLE_RETURN(0);
+}
+
+} // namespace
+
+tls_handshake::tls_handshake(net::const_buffer data)
+  : type(static_cast<handshake_type>(read_value<std::uint8_t>(data)))
+  , size(read_three_byte_value(data))
+  , message(read_message(type, data)) {
+}
+
+tls_record::tls_record(net::const_buffer data)
+  : type(static_cast<record_type>(read_value<std::uint8_t>(data)))
+  , version(static_cast<tls_version>(read_value<std::uint16_t>(data)))
+  , size(read_value<std::uint16_t>(data))
+  , message(read_message(type, data)) {
+}

--- a/test/tls_record.hpp
+++ b/test/tls_record.hpp
@@ -1,0 +1,122 @@
+#ifndef BOOST_WINDOWS_SSPI_TEST_TLS_RECORD
+#define BOOST_WINDOWS_SSPI_TEST_TLS_RECORD
+
+#include <boost/asio.hpp>
+#include <boost/variant.hpp>
+
+#include <cstdint>
+
+namespace net = boost::asio;
+
+enum class tls_version : std::uint16_t {
+  ssl_3_0 = 0x0300,
+  tls_1_0 = 0x0301,
+  tls_1_1 = 0x0302,
+  tls_1_2 = 0x0303
+};
+
+struct tls_change_cipher_spec {
+  // TODO: Implement
+};
+
+struct tls_alert {
+  // TODO: Implement
+};
+
+struct tls_handshake {
+  enum class handshake_type : std::uint8_t {
+    hello_request = 0x00,
+    client_hello = 0x01,
+    server_hello = 0x02,
+    certificate = 0x0b,
+    server_key_exchange = 0x0c,
+    certificate_request = 0x0d,
+    server_done = 0x0e,
+    certificate_verify = 0x0f,
+    client_key_exchange = 0x10,
+    finished = 0x14
+  };
+
+  struct hello_request {
+    // TODO: Implement
+  };
+
+  struct client_hello {
+    // TODO: Implement
+  };
+
+  struct server_hello {
+    // TODO: Implement
+  };
+
+  struct certificate {
+    // TODO: Implement
+  };
+
+  struct server_key_exchange {
+    // TODO: Implement
+  };
+
+  struct certificate_request {
+    // TODO: Implement
+  };
+
+  struct server_done {
+    // TODO: Implement
+  };
+
+  struct certificate_verify {
+    // TODO: Implement
+  };
+
+  struct client_key_exchange {
+    // TODO: Implement
+  };
+
+  struct finished {
+    // TODO: Implement
+  };
+
+  using message_type = boost::variant<hello_request,
+                                      client_hello,
+                                      server_hello,
+                                      certificate,
+                                      server_key_exchange,
+                                      certificate_request,
+                                      server_done,
+                                      certificate_verify,
+                                      client_key_exchange,
+                                      finished>;
+
+  tls_handshake(net::const_buffer data);
+
+  handshake_type type;
+  std::uint32_t size;
+  message_type message;
+};
+
+struct tls_application_data {
+  // TODO: Implement
+};
+
+struct tls_record {
+  enum class record_type : std::uint8_t {
+    change_cipher_spec = 0x14,
+    alert = 0x15,
+    handshake = 0x16,
+    application_data = 0x17
+  };
+
+  using message_type = boost::variant<tls_change_cipher_spec,
+                                      tls_alert,
+                                      tls_handshake,
+                                      tls_application_data>;
+  tls_record(net::const_buffer data);
+
+  record_type type;
+  tls_version version;
+  std::uint16_t size;
+  message_type message;
+};
+
+#endif


### PR DESCRIPTION
This implements the shutdown functionality which was the last thing missing on the client side in order to handle async client communication.

This makes it even more obvious that a lot of code is duplicated and should be deduplicated, but in order to do any of that, some more extensive should first be added.

In order to do that, I have switched to a more feature full test framework (catch2). For now that is mostly to try and focus on actually writing tests even if most of the functionality I use could most likely be written specifically for this library which seems to be what many other boost libraries seems to do.