### PR TITLE
Fix path for doc deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script:
 
 deploy:
   provider: pages
-  local_dir: doc/html
+  local_dir: libs/boost-windows-sspi/doc/html
   github_token: $GITHUB_TOKEN
   keep_history: true
   on:


### PR DESCRIPTION
Deployment seems to be happening from the root of the boost sources,
so fix the path to the generated documentation to reflect that.